### PR TITLE
PullRequest Analysis with Sonarcloud, Travis and Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 plugins {
     id "org.sonarqube" version "2.7.1"
 }
@@ -17,5 +19,17 @@ sonarqube {
     properties {
         property "sonar.projectName", "Java Gradle-based project analyzed on SonarCloud using Travis"
         property "sonar.projectKey", "com.sonarqube.examples.java-gradle-travis-project"
+
+        /*
+        Travis CI provides a Environment Variable called $SONARQUBE_SCANNER_PARAMS, if it is provided and
+        it is populated it will be a json string, if not, it will print the name.
+         */
+
+        String travisSonarProps = System.getProperty("SONARQUBE_SCANNER_PARAMS")
+        if (travisSonarProps!= null && travisSonarProps.isNotEmpty()) {
+            new JsonSlurper().parseText(json).each { key, value ->
+                property(key, value)
+            }
+        }
     }
 }


### PR DESCRIPTION
As the sonarqube gradle plugin is not handling the sonarqube params
from Travis, additional effort is needed to properly parse them
into the plugin.

As the variables are available as one Environment Variable, this
properties can be added to the configuration. The only Problem is
that this Environment Variable contains all the Sonarqube properties
as a JSON-Object in String representation. Hence that parsing via
JSONSlurper is needed.